### PR TITLE
codeql: refine config to include source and exclude test files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+name: CodeQL config – Vue + JS + GitHub Actions
+
+languages: ['javascript']
+
+paths:
+    # Include application source code and workflows
+    - src/
+    - public/
+    - .github/workflows/
+    - cypress/support/
+
+paths-ignore:
+    # Ignore test files, build artefacts, config, lock files, and non-executable docs
+    - cypress/e2e/
+    - node_modules/
+    - dist/
+    - build/
+    - '**/*.config.js'
+    - '**/*.config.mjs'
+    - '**/*.json'
+    - '**/*.md'
+    - '**/*.lock'
+    - '**/__tests__/**'
+    - '**/*.spec.js'
+    - '**/*.test.js'
+
+queries:
+    # GitHub’s extended official security ruleset (more thorough than default)
+    - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: 'CodeQL'
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    schedule:
+        - cron: '0 3 * * 1' # Weekly scan on Monday at 3AM UTC
+
+permissions:
+    security-events: write
+
+jobs:
+    analyze:
+        name: CodeQL Analysis
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build project
+              run: npm run build
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  config-file: .github/codeql/codeql-config.yml
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- Added `.github/codeql/codeql-config.yml` to suit Vue + JavaScript project structure
- Included relevant source directories such as `src/`, `public/`, and non-test Cypress helpers
- Excluded Cypress e2e integration test specs and other non-executable or irrelevant files:
  - `node_modules/`, `dist/`, `build/`
  - config, lock, and markdown files
  - test files matching common spec patterns
- Applied GitHub's `security-extended` ruleset for deeper analysis