### PR TITLE
Remove @vercel/speed-insights and update Node version

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -52,7 +52,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '22.x'
                   cache: 'npm'
 
             - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "0.10.1",
 			"dependencies": {
 				"@vercel/analytics": "^1.5.0",
-				"@vercel/speed-insights": "^1.2.0",
 				"browser-image-compression": "^2.0.2",
 				"moment": "^2.30.1",
 				"vue": "^3.5.18",
@@ -43,7 +42,7 @@
 				"vuefire": "^3.2.2"
 			},
 			"engines": {
-				"node": "20.x"
+				"node": "22.x"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -2306,40 +2305,6 @@
 				"@remix-run/react": {
 					"optional": true
 				},
-				"@sveltejs/kit": {
-					"optional": true
-				},
-				"next": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"svelte": {
-					"optional": true
-				},
-				"vue": {
-					"optional": true
-				},
-				"vue-router": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vercel/speed-insights": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
-			"integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
-			"hasInstallScript": true,
-			"peerDependencies": {
-				"@sveltejs/kit": "^1 || ^2",
-				"next": ">= 13",
-				"react": "^18 || ^19 || ^19.0.0-rc",
-				"svelte": ">= 4",
-				"vue": "^3",
-				"vue-router": "^4"
-			},
-			"peerDependenciesMeta": {
 				"@sveltejs/kit": {
 					"optional": true
 				},
@@ -7085,20 +7050,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 	},
 	"dependencies": {
 		"@vercel/analytics": "^1.5.0",
-		"@vercel/speed-insights": "^1.2.0",
 		"browser-image-compression": "^2.0.2",
 		"moment": "^2.30.1",
 		"vue": "^3.5.18",
@@ -51,7 +50,7 @@
 		"vuefire": "^3.2.2"
 	},
 	"engines": {
-		"node": "20.x"
+		"node": "22.x"
 	},
 	"browserslist": {
 		"production": [


### PR DESCRIPTION
- Deleted @vercel/speed-insights from dependencies
- Updated the required Node.js engine from 20.x to 22.x in package.json. This streamlines dependencies and ensures compatibility with the latest Node.js version.