### PR TITLE
Add @vercel/speed-insights to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.10.1",
 			"dependencies": {
 				"@vercel/analytics": "^1.5.0",
+				"@vercel/speed-insights": "^1.2.0",
 				"browser-image-compression": "^2.0.2",
 				"moment": "^2.30.1",
 				"vue": "^3.5.18",
@@ -2305,6 +2306,41 @@
 				"@remix-run/react": {
 					"optional": true
 				},
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vercel/speed-insights": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+			"integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"svelte": ">= 4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
 				"@sveltejs/kit": {
 					"optional": true
 				},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	},
 	"dependencies": {
 		"@vercel/analytics": "^1.5.0",
+		"@vercel/speed-insights": "^1.2.0",
 		"browser-image-compression": "^2.0.2",
 		"moment": "^2.30.1",
 		"vue": "^3.5.18",


### PR DESCRIPTION
- Added @vercel/speed-insights version 1.2.0 back to package.json and package-lock.json to enable performance monitoring capabilities, as not required to be removed - see previous pull request.