### PR TITLE
Include .vue files in formatting scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 	"scripts": {
 		"dev": "vite",
 		"lint": "eslint src --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0",
-		"lint:fix": "eslint src --fix --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0 && prettier --write '**/*.{vue,js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
-		"format": "prettier --write '**/*.{vue,js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
+		"lint:fix": "eslint src --fix --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0 && prettier --write '**/*.{vue,js,config.js,config.mjs,css,scss,json,md}'",
+		"format": "prettier --write '**/*.{vue,js,config.js,config.mjs,css,scss,json,md}'",
 		"check:dependencies": "mkdir -p scripts/dependency-check && depcheck --txt > scripts/dependency-check/depcheck-output.txt",
 		"cy:open:e2e": "cypress open --e2e",
 		"cy:run:e2e": "cypress run --e2e",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 	"scripts": {
 		"dev": "vite",
 		"lint": "eslint src --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0",
-		"lint:fix": "eslint src --fix --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0 && prettier --write '**/*.{js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
-		"format": "prettier --write '**/*.{js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
+		"lint:fix": "eslint src --fix --config eslint.config.mjs --report-unused-disable-directives --max-warnings 0 && prettier --write '**/*.{vue,js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
+		"format": "prettier --write '**/*.{vue,js,jsx,ts,tsx,config.js,config.mjs,css,scss,json,md}'",
 		"check:dependencies": "mkdir -p scripts/dependency-check && depcheck --txt > scripts/dependency-check/depcheck-output.txt",
 		"cy:open:e2e": "cypress open --e2e",
 		"cy:run:e2e": "cypress run --e2e",


### PR DESCRIPTION
Added .vue file extension to the Prettier and lint:fix scripts in package.json to ensure Vue files are properly formatted and linted.