### PR TITLE
Add GitHub labeler config and PR template

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,81 @@
+# Feature Development
+'feature':
+    - 'src/components/**/*'
+    - 'src/pages/**/*'
+    - 'src/composables/**/*'
+    - 'src/directives/**/*'
+
+# Documentation
+'documentation':
+    - '**/*.md'
+    - '**/README*'
+
+# Dependencies
+'dependencies':
+    - 'package.json'
+    - 'package-lock.json'
+    - '.npmrc'
+    - '.nvmrc'
+
+# Testing
+'testing':
+    - 'src/**/*.test.*'
+    - 'src/**/*.spec.*'
+    - 'cypress/**/*'
+    - 'cypress.config.*'
+
+# Styling
+'styling':
+    - '**/*.css'
+    - '**/*.scss'
+    - 'src/styles/**/*'
+
+# State Management (Vuex)
+'store':
+    - 'src/store/**/*'
+
+# Configuration
+'config':
+    - 'vite.config.*'
+    - 'eslint.config.*'
+    - '.eslintrc*'
+    - 'prettier.config.*'
+    - '.prettierrc*'
+    - '.prettierignore'
+    - 'vercel.json'
+    - 'rules/**/*'
+    - 'index.html'
+
+# Constants
+'constants':
+    - 'src/constants/**/*'
+
+# Utilities
+'utilities':
+    - 'src/utils/**/*'
+
+# Firebase
+'firebase':
+    - 'src/firebase.js'
+    - '.firebaserc'
+
+# Vue Core Files
+'vue-core':
+    - 'src/App.vue'
+    - 'src/main.js'
+    - 'src/router.js'
+
+# Assets
+'assets':
+    - 'src/assets/**/*'
+    - 'public/**/*'
+    - '**/*.{png,jpg,jpeg,gif,svg,ico,woff,woff2}'
+
+# Build/Deployment
+'build/deployment':
+    - '.github/workflows/**/*'
+    - 'vercel.json'
+
+# Environment
+'environment':
+    - '.gitignore'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+
+Brief description of changes
+
+## Type of Change
+
+- [ ] 🚀 Feature
+- [ ] 🐛 Bug fix
+- [ ] 📚 Documentation
+- [ ] 🔧 Refactor
+- [ ] ⚡ Performance
+- [ ] 🧪 Tests
+
+## Checklist
+
+- [ ] Added appropriate labels
+- [ ] Tests pass
+- [ ] Documentation updated
+- [ ] Ready for review
+
+**🏷️ Remember to add labels before submitting!**

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,13 @@
+name: Auto Label PRs
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+jobs:
+    label:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/labeler@v4
+              with:
+                  repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Introduces .github/labeler.yml for automated PR labeling, a pull request template to standardize submissions, and a workflow to auto-label PRs using GitHub Actions. These changes improve repository organization and streamline the review process.